### PR TITLE
Fix subclassing `HermesNotificationView`

### DIFF
--- a/Hermes/HermesNotificationView.swift
+++ b/Hermes/HermesNotificationView.swift
@@ -7,8 +7,8 @@ public class HermesNotificationView: UIView {
   required public init(coder aDecoder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
-    
-  override init(frame: CGRect) {
+
+  public override init(frame: CGRect) {
     super.init(frame: frame)
     addSubview(contentView)
   }

--- a/Hermes/HermesNotificationView.swift
+++ b/Hermes/HermesNotificationView.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 public class HermesNotificationView: UIView {
-  var notification: HermesNotification?
+  public var notification: HermesNotification?
   let contentView = UIView()
     
   required public init(coder aDecoder: NSCoder) {


### PR DESCRIPTION
When used as a pod, subclassing `HermesNotificationView` doesn't let you overrides `init:frame:` or `notification`
because they are not made public.
